### PR TITLE
Api cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 __pycache__
 node_modules
+.env*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Not intended for wide reaching use.
   - Take a trip and have it calculate the 2-3 top cabins and stage a second round of voting
 - [X] Proper env variables. Mainly just the URL endpoint that's hit
 - [ ] Make use of the Docker compose networking so the UI can hit the API without having to expose the API directly over the internet
-- [ ] Better UI for the cards (bottom padding is missing)
+- [X] Better UI for the cards (bottom padding is missing)
 - [ ] Proper user support over some SSO would be great. Hell I'll take a username and password. Just something better than nothing
 - [ ] Split these apart into separate repos
   - This isn't really needed since this is just a side project for fun so it's low priority. But proper project structures should really be followed
@@ -16,6 +16,7 @@ Not intended for wide reaching use.
   - Images vary in size and without set card dimensions, they can become ever so slightly bigger or smaller and it offsets the rows
 - [ ] Access control to Cabins and trips
   - needs proper user support
+- [ ] Pre-commit hooks for enforcing prettier code formatting
 
 # Running the app
 

--- a/README.md
+++ b/README.md
@@ -54,3 +54,6 @@ Unsure right now. Spin up a Postgres 14 container and map the network informatio
 
 There is a docker-compose yaml that'll build all 3 containers for the app. Unraid has community support for docker
 compose. So I will attempt to use that.
+
+## Building
+`cd` into the `cabin_site` & `frontend` directories and build the respective Dockerfiles in there: `docker build -t my_docker_repo/my_app:<frontend/backend> .`. Push these two containers to the Dockerhub and deploy on Unraid

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Not intended for wide reaching use.
 
 # TODOs
 
-- [ ] Proper API Class (so we don't have many axios calls everywhere)
+- [X] Proper API Class (so we don't have many axios calls everywhere)
 - [ ] Secondary voting rounds
   - Take a trip and have it calculate the 2-3 top cabins and stage a second round of voting
 - [ ] Proper env variables. Mainly just the URL endpoint that's hit

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Not intended for wide reaching use.
 - [X] Proper API Class (so we don't have many axios calls everywhere)
 - [ ] Secondary voting rounds
   - Take a trip and have it calculate the 2-3 top cabins and stage a second round of voting
-- [ ] Proper env variables. Mainly just the URL endpoint that's hit
+- [X] Proper env variables. Mainly just the URL endpoint that's hit
 - [ ] Make use of the Docker compose networking so the UI can hit the API without having to expose the API directly over the internet
 - [ ] Better UI for the cards (bottom padding is missing)
 - [ ] Proper user support over some SSO would be great. Hell I'll take a username and password. Just something better than nothing

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,9 @@ const App = () => {
               <Nav.Link as={Link} to='trips'>
                 Trips
               </Nav.Link>
+              <div>
+                Running {process.env.NODE_ENV} mode. Will use {process.env.REACT_APP_BACKEND_URL} for URL calls
+              </div>
             </Nav>
           </Navbar.Collapse>
           <Navbar.Collapse className='justify-content-end'>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,9 +21,12 @@ const App = () => {
               <Nav.Link as={Link} to='trips'>
                 Trips
               </Nav.Link>
-              <div>
-                Running {process.env.NODE_ENV} mode. Will use {process.env.REACT_APP_BACKEND_URL} for URL calls
-              </div>
+              {process.env.NODE_ENV === 'development' && (
+                <div>
+                  Running {process.env.NODE_ENV} mode. Will use {process.env.REACT_APP_BACKEND_URL}{' '}
+                  for URL calls
+                </div>
+              )}
             </Nav>
           </Navbar.Collapse>
           <Navbar.Collapse className='justify-content-end'>

--- a/frontend/src/components/Cabins/CabinFormModal.jsx
+++ b/frontend/src/components/Cabins/CabinFormModal.jsx
@@ -3,6 +3,7 @@ import { Form, Modal, Button, Alert, InputGroup } from 'react-bootstrap';
 import axios from 'axios';
 import { STATE_OPTIONS } from '../../constants';
 import useRequest from '../../hooks/useRequest';
+import CabinAPI from '../../utils/api/CabinAPI';
 
 const CabinFormModal = ({
   isOpen,
@@ -48,21 +49,9 @@ const CabinFormModal = ({
 
     try {
       if (isEdit) {
-        response = await axios.patch(
-          `https://cabin-db.mattpassarelli.net/cabins/${selectedCabin.id}/`,
-          data,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          }
-        );
+        response = await CabinAPI.updateCabin(selectedCabin.id, data);
       } else {
-        response = await axios.post('https://cabin-db.mattpassarelli.net/cabins/', data, {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
+        response = await CabinAPI.createCabin(data);
       }
 
       if (response.status === 201) {
@@ -87,7 +76,7 @@ const CabinFormModal = ({
     request: deleteCabin,
   } = useRequest(
     useCallback(async () => {
-      await axios.delete(`https://cabin-db.mattpassarelli.net/cabins/${selectedCabin.id}/`);
+      await CabinAPI.deleteCabin(selectedCabin.id);
 
       fetchItems();
       handleClose();

--- a/frontend/src/components/Cabins/CabinFormModal.jsx
+++ b/frontend/src/components/Cabins/CabinFormModal.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react';
 import { Form, Modal, Button, Alert, InputGroup } from 'react-bootstrap';
-import axios from 'axios';
 import { STATE_OPTIONS } from '../../constants';
 import useRequest from '../../hooks/useRequest';
 import CabinAPI from '../../utils/api/CabinAPI';
@@ -70,11 +69,7 @@ const CabinFormModal = ({
     }
   };
 
-  const {
-    isLoading: isDeleting,
-    error: errorDeleting,
-    request: deleteCabin,
-  } = useRequest(
+  const { isLoading: isDeleting, request: deleteCabin } = useRequest(
     useCallback(async () => {
       await CabinAPI.deleteCabin(selectedCabin.id);
 

--- a/frontend/src/components/Trips/TripFormModal.jsx
+++ b/frontend/src/components/Trips/TripFormModal.jsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import React, { useState, useCallback } from 'react';
 import { Alert, Button, Form, Modal } from 'react-bootstrap';
 import useRequest from '../../hooks/useRequest';
@@ -19,37 +18,36 @@ const TripFormModal = ({ isOpen, closeModal, isEdit = false, item, reloadTrips }
     setValidated(false);
   };
 
-  const {
-    isLoading: isSubmitting,
-    error: saveError,
-    request: submitTrip,
-  } = useRequest(
-    useCallback(async (event) => {
-      event.preventDefault();
+  const { error: saveError, request: submitTrip } = useRequest(
+    useCallback(
+      async (event) => {
+        event.preventDefault();
 
-      const form = event.currentTarget;
-      if (form.checkValidity() === false || tripYear < new Date().getFullYear()) {
-        event.stopPropagation();
-        setValidated(true);
-        return;
-      }
+        const form = event.currentTarget;
+        if (form.checkValidity() === false || tripYear < new Date().getFullYear()) {
+          event.stopPropagation();
+          setValidated(true);
+          return;
+        }
 
-      const data = {
-        year: tripYear,
-        start_date: startDate,
-        end_date: endDate,
-      };
+        const data = {
+          year: tripYear,
+          start_date: startDate,
+          end_date: endDate,
+        };
 
-      if (isEdit) {
-        await TripAPI.updateTrip(tripId, data);
-      } else {
-        await TripAPI.createTrip(data);
-      }
+        if (isEdit) {
+          await TripAPI.updateTrip(tripId, data);
+        } else {
+          await TripAPI.createTrip(data);
+        }
 
-      resetForm();
-      reloadTrips();
-      closeModal();
-    }),
+        resetForm();
+        reloadTrips();
+        closeModal();
+      },
+      []
+    ),
     []
   );
 

--- a/frontend/src/components/Trips/TripFormModal.jsx
+++ b/frontend/src/components/Trips/TripFormModal.jsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import React, { useState, useCallback } from 'react';
 import { Alert, Button, Form, Modal } from 'react-bootstrap';
 import useRequest from '../../hooks/useRequest';
+import { TripAPI } from '../../utils/api';
 
 const TripFormModal = ({ isOpen, closeModal, isEdit = false, item, reloadTrips }) => {
   const [validated, setValidated] = useState(false);
@@ -40,17 +41,9 @@ const TripFormModal = ({ isOpen, closeModal, isEdit = false, item, reloadTrips }
       };
 
       if (isEdit) {
-        await axios.patch(`https://cabin-db.mattpassarelli.net/trips/${tripId}/`, data, {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
+        await TripAPI.updateTrip(tripId, data);
       } else {
-        await axios.post('https://cabin-db.mattpassarelli.net/trips/', data, {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
+        await TripAPI.createTrip(data);
       }
 
       resetForm();

--- a/frontend/src/components/UserForm.jsx
+++ b/frontend/src/components/UserForm.jsx
@@ -2,6 +2,7 @@ import { Button, Form } from 'react-bootstrap';
 import React, { useEffect, useState } from 'react';
 import Modal from 'react-bootstrap/Modal';
 import { redirect } from 'react-router-dom';
+import UserAPI from '../utils/api/UserAPI';
 
 const UserForm = () => {
   const [renderForm, setRenderForm] = useState(false);
@@ -30,16 +31,9 @@ const UserForm = () => {
       return;
     }
 
-    const response = await fetch('https://cabin-db.mattpassarelli.net/users/', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ name: username }),
-    });
+    const response = await UserAPI.createUser({ name: username });
 
-
-    if (response.ok) {
+    if (response.status === 200 || response.status === 201) {
       localStorage.setItem('userName', username);
       setRenderForm(false);
 

--- a/frontend/src/screens/Cabins/CabinItem.jsx
+++ b/frontend/src/screens/Cabins/CabinItem.jsx
@@ -3,6 +3,7 @@ import { Button, Card } from 'react-bootstrap';
 import CabinFormModal from '../../components/Cabins/CabinFormModal';
 import useRequest from '../../hooks/useRequest';
 import axios from 'axios';
+import CabinAPI from '../../utils/api/CabinAPI';
 
 const CabinItem = ({ cabin, fetchCabins, tripId }) => {
   const [showEdit, setShowEdit] = useState(false);
@@ -19,17 +20,7 @@ const CabinItem = ({ cabin, fetchCabins, tripId }) => {
     request: toggleVote,
   } = useRequest(
     useCallback(async () => {
-      await axios.post(
-        `https://cabin-db.mattpassarelli.net/cabins/${cabin.id}/vote/`,
-        {
-          user: localStorage.getItem('userName'),
-        },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
-      );
+      await CabinAPI.toggleVote(cabin.id, localStorage.getItem('userName'));
 
       fetchCabins();
     }, [])

--- a/frontend/src/screens/Cabins/CabinItem.jsx
+++ b/frontend/src/screens/Cabins/CabinItem.jsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from 'react';
 import { Button, Card } from 'react-bootstrap';
 import CabinFormModal from '../../components/Cabins/CabinFormModal';
 import useRequest from '../../hooks/useRequest';
-import axios from 'axios';
 import CabinAPI from '../../utils/api/CabinAPI';
 
 const CabinItem = ({ cabin, fetchCabins, tripId }) => {
@@ -15,15 +14,13 @@ const CabinItem = ({ cabin, fetchCabins, tripId }) => {
   };
 
   const {
-    isLoading,
-    error,
     request: toggleVote,
   } = useRequest(
     useCallback(async () => {
       await CabinAPI.toggleVote(cabin.id, localStorage.getItem('userName'));
 
       fetchCabins();
-    }, [])
+    }, [cabin.id, fetchCabins])
   );
 
   return (

--- a/frontend/src/screens/Cabins/Cabins.jsx
+++ b/frontend/src/screens/Cabins/Cabins.jsx
@@ -7,6 +7,7 @@ import axios from 'axios';
 
 import useRequest from '../../hooks/useRequest';
 import CabinItem from './CabinItem';
+import CabinAPI from '../../utils/api/CabinAPI';
 
 const Cabins = () => {
   const { tripId } = useParams();
@@ -19,9 +20,7 @@ const Cabins = () => {
     request: fetchCabins,
   } = useRequest(
     useCallback(async () => {
-      const response = await axios.get(
-        `https://cabin-db.mattpassarelli.net/trips/${tripId}/cabins/`
-      );
+      const response = await CabinAPI.getCabinsByTripId(tripId);
 
       return {
         cabins: response.data.cabins,

--- a/frontend/src/screens/Cabins/Cabins.jsx
+++ b/frontend/src/screens/Cabins/Cabins.jsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Container, Button, Card, Row, Col } from 'react-bootstrap';
-import { Link, useParams } from 'react-router-dom';
+import { Container, Button, Row, Col } from 'react-bootstrap';
+import { useParams } from 'react-router-dom';
 import CabinFormModal from '../../components/Cabins/CabinFormModal';
 
-import axios from 'axios';
 
 import useRequest from '../../hooks/useRequest';
 import CabinItem from './CabinItem';
@@ -16,7 +15,6 @@ const Cabins = () => {
   const {
     result: { cabins },
     isLoading,
-    error,
     request: fetchCabins,
   } = useRequest(
     useCallback(async () => {
@@ -25,13 +23,13 @@ const Cabins = () => {
       return {
         cabins: response.data.cabins,
       };
-    }, []),
+    }, [tripId]),
     { cabins: [] }
   );
 
   useEffect(() => {
     fetchCabins();
-  }, []);
+  }, [fetchCabins]);
 
   return (
     <Container>

--- a/frontend/src/screens/Trips/TripDetail.jsx
+++ b/frontend/src/screens/Trips/TripDetail.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import useRequest from '../../hooks/useRequest';
 import axios from 'axios';
 import TripCreateModal from '../../components/Trips/TripFormModal';
+import { TripAPI } from '../../utils/api';
 
 const TripDetail = ({ item, fetchTrips }) => {
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -22,7 +23,7 @@ const TripDetail = ({ item, fetchTrips }) => {
     request: deleteTrip,
   } = useRequest(
     useCallback(async () => {
-      await axios.delete(`https://cabin-db.mattpassarelli.net/trips/${item.id}/`);
+      await TripAPI.deleteTrip(item.id);
     }, []),
     {
       trips: [],

--- a/frontend/src/screens/Trips/TripDetail.jsx
+++ b/frontend/src/screens/Trips/TripDetail.jsx
@@ -3,7 +3,6 @@ import { Button, Modal } from 'react-bootstrap';
 
 import { Link } from 'react-router-dom';
 import useRequest from '../../hooks/useRequest';
-import axios from 'axios';
 import TripCreateModal from '../../components/Trips/TripFormModal';
 import { TripAPI } from '../../utils/api';
 
@@ -19,12 +18,11 @@ const TripDetail = ({ item, fetchTrips }) => {
 
   const {
     isLoading: isDeleting,
-    error: errorDeleting,
     request: deleteTrip,
   } = useRequest(
     useCallback(async () => {
       await TripAPI.deleteTrip(item.id);
-    }, []),
+    }, [item.id]),
     {
       trips: [],
     }

--- a/frontend/src/screens/Trips/Trips.jsx
+++ b/frontend/src/screens/Trips/Trips.jsx
@@ -4,7 +4,8 @@ import { Button, Container, Form, Modal, Spinner, Table } from 'react-bootstrap'
 
 import useRequest from '../../hooks/useRequest';
 import TripDetail from './TripDetail';
-import TripCreateModal from '../../components/Trips/TripFormModal';
+import TripFormModal from '../../components/Trips/TripFormModal';
+import { TripAPI } from '../../utils/api';
 
 const Trips = () => {
   const [open, setOpen] = useState(false);
@@ -16,7 +17,7 @@ const Trips = () => {
     request: fetchTrips,
   } = useRequest(
     useCallback(async () => {
-      const response = await axios.get('https://cabin-db.mattpassarelli.net/trips/');
+      const response = await TripAPI.getTrips();
 
       return {
         trips: response.data,
@@ -55,7 +56,7 @@ const Trips = () => {
         </Table>
       )}
 
-      <TripCreateModal isOpen={open} closeModal={() => setOpen(false)} reloadTrips={fetchTrips} />
+      <TripFormModal isOpen={open} closeModal={() => setOpen(false)} reloadTrips={fetchTrips} />
     </Container>
   );
 };

--- a/frontend/src/screens/Trips/Trips.jsx
+++ b/frontend/src/screens/Trips/Trips.jsx
@@ -1,6 +1,5 @@
-import axios from 'axios';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Button, Container, Form, Modal, Spinner, Table } from 'react-bootstrap';
+import { Button, Container, Spinner, Table } from 'react-bootstrap';
 
 import useRequest from '../../hooks/useRequest';
 import TripDetail from './TripDetail';
@@ -13,7 +12,6 @@ const Trips = () => {
   const {
     result: { trips },
     isLoading,
-    error,
     request: fetchTrips,
   } = useRequest(
     useCallback(async () => {
@@ -30,7 +28,7 @@ const Trips = () => {
 
   useEffect(() => {
     fetchTrips();
-  }, []);
+  }, [fetchTrips]);
 
   return (
     <Container>

--- a/frontend/src/utils/api/BaseAPI.js
+++ b/frontend/src/utils/api/BaseAPI.js
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
-const BASE_URL = 'http://localhost:8000';
-
 class BaseAPI {
-  constructor(baseURL = BASE_URL) {
+  constructor(baseURL = process.env.REACT_APP_BACKEND_URL) {
     this.axiosInstance = axios.create({
       baseURL: baseURL,
       headers: {

--- a/frontend/src/utils/api/BaseAPI.js
+++ b/frontend/src/utils/api/BaseAPI.js
@@ -1,0 +1,32 @@
+import axios from 'axios';
+
+const BASE_URL = 'http://localhost:8000';
+
+class BaseAPI {
+  constructor(baseURL = BASE_URL) {
+    this.axiosInstance = axios.create({
+      baseURL: baseURL,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  get(endpoint, params = {}) {
+    return this.axiosInstance.get(endpoint, { params });
+  }
+
+  post(endpoint, data) {
+    return this.axiosInstance.post(endpoint, data);
+  }
+
+  patch(endpoint, data) {
+    return this.axiosInstance.patch(endpoint, data);
+  }
+
+  delete(endpoint) {
+    return this.axiosInstance.delete(endpoint);
+  }
+}
+
+export default BaseAPI;

--- a/frontend/src/utils/api/CabinAPI.js
+++ b/frontend/src/utils/api/CabinAPI.js
@@ -1,10 +1,6 @@
 import BaseAPI from './BaseAPI';
 
 class CabinAPI extends BaseAPI {
-  constructor() {
-    super();
-  }
-
   getCabinsByTripId(tripId) {
     return this.get(`/trips/${tripId}/cabins/`);
   }

--- a/frontend/src/utils/api/CabinAPI.js
+++ b/frontend/src/utils/api/CabinAPI.js
@@ -1,0 +1,31 @@
+import BaseAPI from './BaseAPI';
+
+class CabinAPI extends BaseAPI {
+  constructor() {
+    super();
+  }
+
+  getCabinsByTripId(tripId) {
+    return this.get(`/trips/${tripId}/cabins/`);
+  }
+
+  updateCabin(cabinId, data) {
+    return this.patch(`/cabins/${cabinId}/`, data);
+  }
+
+  createCabin(data) {
+    return this.post('/cabins/', data);
+  }
+
+  deleteCabin(cabinId) {
+    return this.delete(`/cabins/${cabinId}/`);
+  }
+
+  toggleVote(cabinId, userName) {
+    return this.post(`/cabins/${cabinId}/vote/`, {
+      user: userName,
+    });
+  }
+}
+
+export default new CabinAPI();

--- a/frontend/src/utils/api/TripAPI.js
+++ b/frontend/src/utils/api/TripAPI.js
@@ -1,0 +1,25 @@
+import BaseAPI from './BaseAPI';
+
+class TripAPI extends BaseAPI {
+  constructor() {
+    super();
+  }
+
+  getTrips() {
+    return this.get('/trips/');
+  }
+
+  updateTrip(tripId, data) {
+    return this.patch(`/trips/${tripId}/`, data);
+  }
+
+  createTrip(data) {
+    return this.post(`/trips/`, data);
+  }
+
+  deleteTrip(tripId) {
+    return this.delete(`/trips/${tripId}/`)
+  }
+}
+
+export default new TripAPI();

--- a/frontend/src/utils/api/TripAPI.js
+++ b/frontend/src/utils/api/TripAPI.js
@@ -1,10 +1,6 @@
 import BaseAPI from './BaseAPI';
 
 class TripAPI extends BaseAPI {
-  constructor() {
-    super();
-  }
-
   getTrips() {
     return this.get('/trips/');
   }
@@ -18,7 +14,7 @@ class TripAPI extends BaseAPI {
   }
 
   deleteTrip(tripId) {
-    return this.delete(`/trips/${tripId}/`)
+    return this.delete(`/trips/${tripId}/`);
   }
 }
 

--- a/frontend/src/utils/api/UserAPI.js
+++ b/frontend/src/utils/api/UserAPI.js
@@ -1,0 +1,13 @@
+import BaseAPI from './BaseAPI';
+
+class UserAPI extends BaseAPI {
+  constructor() {
+    super();
+  }
+
+  createUser(userData) {
+    return this.post(`/users/`, userData);
+  }
+}
+
+export default new UserAPI();

--- a/frontend/src/utils/api/UserAPI.js
+++ b/frontend/src/utils/api/UserAPI.js
@@ -1,10 +1,6 @@
 import BaseAPI from './BaseAPI';
 
 class UserAPI extends BaseAPI {
-  constructor() {
-    super();
-  }
-
   createUser(userData) {
     return this.post(`/users/`, userData);
   }

--- a/frontend/src/utils/api/index.js
+++ b/frontend/src/utils/api/index.js
@@ -1,0 +1,5 @@
+import UserAPI from './UserAPI';
+import TripAPI from './TripAPI';
+import CabinAPI from './CabinAPI';
+
+export { UserAPI, TripAPI, CabinAPI };


### PR DESCRIPTION
Added a BaseAPI class that is extended by Model based API classes. Makes it really easy to have cleaner looking API calls across everything.

Also added `.env` files so the URLs aren't just in the code anymore. I don't really mind the domain name being in history. I'll clear it from Cloudflare when we finish this year's cabin voting. But it also won't be needed once I get around to the Docker networking stuff.